### PR TITLE
Correct French league name

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ soccer --help
 ### List of supported leagues and their league codes
 
 - BL: Bundesliga (German League)
-- FL: Ligue One (French League)
+- FL: Ligue 1 (French League)
 - EPL: English Premier League
 - LLIGA: Liga BBVA (Spanish League)
 - SA: Serie A  (Italian League)


### PR DESCRIPTION
It is written as "Ligue 1" everywhere rather than "Ligue One".

http://www.ligue1.com
https://en.wikipedia.org/wiki/Ligue_1