### PR TITLE
Colour support on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ setup(
   scripts=['main.py', 'leagueids.py', 'authtoken.py', 'teamnames.py', 'liveapi.py'],
   install_requires=[
     "click==5.0",
-    "requests==2.7.0",
-  ] + ["colorama==0.3.3"] if "win" in sys.platform else [],
+    "requests==2.7.0"
+  ] + (["colorama==0.3.3"] if "win" in sys.platform else []),
   entry_points = {
     'console_scripts': [
         'soccer = main:main'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from setuptools import setup
+import sys
 
 setup(
   name='soccer-cli',
@@ -35,7 +36,7 @@ setup(
   install_requires=[
     "click==5.0",
     "requests==2.7.0",
-  ],
+  ] + ["colorama==0.3.3"] if "win" in sys.platform else [],
   entry_points = {
     'console_scripts': [
         'soccer = main:main'


### PR DESCRIPTION
If user is running Windows, install colorama. Colours won't work on Windows otherwise.

https://github.com/tartley/colorama
http://click.pocoo.org/5/utils/#ansi-colors

I have tested this on Windows and Linux. It installs colorama only on the Windows setup.

I don't think it is essential to have this but at the very least there should be a note in the README.md that says something like:

> **Windows users:** If you want colours then run `pip install colorama`

Maybe that is just simpler, idk.