### PR TITLE
Remove liveapi.py reference in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
   keywords = "soccer football espn scores live tool cli",
   author_email='architv07@gmail.com',
   url='https://github.com/architv/soccer-cli',
-  scripts=['main.py', 'leagueids.py', 'authtoken.py', 'teamnames.py', 'liveapi.py'],
+  scripts=['main.py', 'leagueids.py', 'authtoken.py', 'teamnames.py'],
   install_requires=[
     "click==5.0",
     "requests==2.7.0"


### PR DESCRIPTION
This file is no longer needed ad0409d7a30009af13b03325d845df948559d5ff


When running `python setup.py install`:
```
copying and adjusting main.py -> build/scripts-2.7
copying leagueids.py -> build/scripts-2.7
copying authtoken.py -> build/scripts-2.7
copying teamnames.py -> build/scripts-2.7
error: file '/projects/soccer-cli/liveapi.py' does not exist
```