### PR TITLE
Fix module bin install issue #16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
   keywords = "soccer football espn scores live tool cli",
   author_email='architv07@gmail.com',
   url='https://github.com/architv/soccer-cli',
-  scripts=['main.py', 'leagueids.py', 'authtoken.py', 'teamnames.py'],
+  py_modules=['main', 'leagueids', 'authtoken', 'teamnames'],
   install_requires=[
     "click>=5.0",
     "requests==2.7.0"


### PR DESCRIPTION
Fix architv/soccer-cli#16

Previously the setup script places 'main.py', 'leagueids.py' etc into
the /bin folder along with the 'soccer' script.

This was not desired as it meant not only was the `soccer` command
available via the command line (nice!)  but typing `main.py` or `leagueids.py`
would also run the python scripts...

This change means that only `soccer` gets placed in the /bin folder.


**Before**
![not_working](https://cloud.githubusercontent.com/assets/3779458/9701002/e7d11262-540f-11e5-8fd0-fd4bc1cca774.PNG)


**After**
![working](https://cloud.githubusercontent.com/assets/3779458/9700984/7736be62-540f-11e5-9afc-c97bc6b0271f.PNG)