### PR TITLE
Goal difference column alignment fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,24 +111,24 @@ def get_standings(league):
 def print_standings(league_table, league):
 	""" Prints the league standings in a pretty way """
 
-	click.secho("%-6s  %-30s    %-11s    %-10s    %-10s" %
+	click.secho("%-6s  %-30s    %-10s    %-10s    %-10s" %
 				( "POS", "CLUB", "PLAYED", "GOAL DIFF", "POINTS"))
 	positionlist = [team["position"] for team in league_table["standing"]]
 	for team in league_table["standing"]:
 		if team["goalDifference"] >= 0:
 			team["goalDifference"] = ' ' + str(team["goalDifference"])
 		if LEAGUE_PROPERTIES[league]["cl"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["cl"][1]:
-			click.secho("%-6s  %-30s    %-10s    %-11s    %-10s" %
+			click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" %
 				(str(team["position"]), team["teamName"],
 				str(team["playedGames"]), team["goalDifference"],str(team["points"])),
 				bold=True, fg="green")
 		elif LEAGUE_PROPERTIES[league]["rl"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["rl"][1]:  # 5-15 in BL, 5-17 in others
-			click.secho("%-6s  %-30s    %-10s    %-11s    %-10s" %
+			click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" %
 				(str(team["position"]), team["teamName"],
 				str(team["playedGames"]), team["goalDifference"],str(team["points"])),
 				fg="red")
 		else:
-			click.secho("%-6s  %-30s    %-10s    %-11s    %-10s" %
+			click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" %
 				(str(team["position"]), team["teamName"],
 				str(team["playedGames"]), team["goalDifference"],str(team["points"])),
 				fg="blue")

--- a/main.py
+++ b/main.py
@@ -115,20 +115,22 @@ def print_standings(league_table, league):
 				( "POS", "CLUB", "PLAYED", "GOAL DIFF", "POINTS"))
 	positionlist = [team["position"] for team in league_table["standing"]]
 	for team in league_table["standing"]:
+		if team["goalDifference"] >= 0:
+			team["goalDifference"] = ' ' + str(team["goalDifference"])
 		if LEAGUE_PROPERTIES[league]["cl"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["cl"][1]:
 			click.secho("%-6s  %-30s    %-10s    %-10s    %-10s" %
 				(str(team["position"]), team["teamName"],
-				str(team["playedGames"]), str(team["goalDifference"]),str(team["points"])),
+				str(team["playedGames"]), team["goalDifference"],str(team["points"])),
 				bold=True, fg="green")
 		elif LEAGUE_PROPERTIES[league]["rl"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["rl"][1]:  # 5-15 in BL, 5-17 in others
 			click.secho("%-6s  %-30s    %-10s    %-10s    %-10s" %
 				(str(team["position"]), team["teamName"],
-				str(team["playedGames"]), str(team["goalDifference"]),str(team["points"])),
+				str(team["playedGames"]), team["goalDifference"],str(team["points"])),
 				fg="red")
 		else:
 			click.secho("%-6s  %-30s    %-10s    %-10s    %-10s" %
 				(str(team["position"]), team["teamName"],
-				str(team["playedGames"]), str(team["goalDifference"]),str(team["points"])),
+				str(team["playedGames"]), team["goalDifference"],str(team["points"])),
 				fg="blue")
 
 

--- a/main.py
+++ b/main.py
@@ -111,24 +111,24 @@ def get_standings(league):
 def print_standings(league_table, league):
 	""" Prints the league standings in a pretty way """
 
-	click.secho("%-6s  %-30s    %-10s    %-10s    %-10s" %
+	click.secho("%-6s  %-30s    %-11s    %-10s    %-10s" %
 				( "POS", "CLUB", "PLAYED", "GOAL DIFF", "POINTS"))
 	positionlist = [team["position"] for team in league_table["standing"]]
 	for team in league_table["standing"]:
 		if team["goalDifference"] >= 0:
 			team["goalDifference"] = ' ' + str(team["goalDifference"])
 		if LEAGUE_PROPERTIES[league]["cl"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["cl"][1]:
-			click.secho("%-6s  %-30s    %-10s    %-10s    %-10s" %
+			click.secho("%-6s  %-30s    %-10s    %-11s    %-10s" %
 				(str(team["position"]), team["teamName"],
 				str(team["playedGames"]), team["goalDifference"],str(team["points"])),
 				bold=True, fg="green")
 		elif LEAGUE_PROPERTIES[league]["rl"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["rl"][1]:  # 5-15 in BL, 5-17 in others
-			click.secho("%-6s  %-30s    %-10s    %-10s    %-10s" %
+			click.secho("%-6s  %-30s    %-10s    %-11s    %-10s" %
 				(str(team["position"]), team["teamName"],
 				str(team["playedGames"]), team["goalDifference"],str(team["points"])),
 				fg="red")
 		else:
-			click.secho("%-6s  %-30s    %-10s    %-10s    %-10s" %
+			click.secho("%-6s  %-30s    %-10s    %-11s    %-10s" %
 				(str(team["position"]), team["teamName"],
 				str(team["playedGames"]), team["goalDifference"],str(team["points"])),
 				fg="blue")


### PR DESCRIPTION
This fixes the alignment of the goal difference column. Since negative numbers kind of make it look crooked when printed on the console.

It simply adds a space before numbers >= 0. This makes all the numbers line up.

I think it looks better from a visual point of view.

**Before**
```
POS     CLUB                              PLAYED        GOAL DIFF     POINTS    
1       Borussia Dortmund                 3             10            9         
2       FC Bayern München                 3             9             9         
3       VfL Wolfsburg                     3             4             7         
4       1. FC Köln                        3             3             7         
5       1. FSV Mainz 05                   3             3             6         
6       Bayer Leverkusen                  3             -1            6         
7       FC Ingolstadt 04                  3             -2            6         
8       Eintracht Frankfurt               3             2             4         
9       FC Schalke 04                     3             0             4         
10      Hertha BSC                        3             -1            4         
11      Werder Bremen                     3             -2            4         
12      SV Darmstadt 98                   3             0             3         
13      Hamburger SV                      3             -5            3         
14      TSG 1899 Hoffenheim               3             -2            1         
15      FC Augsburg                       3             -2            1         
16      Hannover 96                       3             -4            1         
17      VfB Stuttgart                     3             -6            0         
18      Bor. Mönchengladbach              3             -6            0 
```
**After**
```
POS     CLUB                              PLAYED        GOAL DIFF     POINTS    
1       Borussia Dortmund                 3             10            9         
2       FC Bayern München                 3             9             9         
3       VfL Wolfsburg                     3             4             7         
4       1. FC Köln                        3             3             7         
5       1. FSV Mainz 05                   3             3             6         
6       Bayer Leverkusen                  3            -1             6         
7       FC Ingolstadt 04                  3            -2             6         
8       Eintracht Frankfurt               3             2             4         
9       FC Schalke 04                     3             0             4         
10      Hertha BSC                        3            -1             4         
11      Werder Bremen                     3            -2             4         
12      SV Darmstadt 98                   3             0             3         
13      Hamburger SV                      3            -5             3         
14      TSG 1899 Hoffenheim               3            -2             1         
15      FC Augsburg                       3            -2             1         
16      Hannover 96                       3            -4             1         
17      VfB Stuttgart                     3            -6             0         
18      Bor. Mönchengladbach              3            -6             0  
```