### PR TITLE
Replace reading auth token from a file with using an environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.pyc
-authtoken.py
 README
 README.txt
 

--- a/main.py
+++ b/main.py
@@ -2,9 +2,9 @@
 
 import click
 import json
+import os
 import requests
 
-import authtoken
 import leagueids
 import leagueproperties
 import teamnames
@@ -15,8 +15,15 @@ LEAGUE_IDS = leagueids.LEAGUE_IDS
 TEAM_NAMES = teamnames.team_names
 LEAGUE_PROPERTIES = leagueproperties.LEAGUE_PROPERTIES
 
+class APITokenException(Exception):
+    pass
+
+auth_token = os.environ.get('API_TOKEN')
+if not auth_token:
+    raise APITokenException('No API Token found.')
+
 headers = {
-    'X-Auth-Token': authtoken.API_TOKEN
+    'X-Auth-Token': auth_token
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     keywords = "soccer football espn scores live tool cli",
     author_email='architv07@gmail.com',
     url='https://github.com/architv/soccer-cli',
-    py_modules=['main', 'leagueids', 'authtoken', 'teamnames', 'leagueproperties'],
+    py_modules=['main', 'leagueids', 'teamnames', 'leagueproperties'],
     install_requires=[
         "click>=5.0",
         "requests==2.7.0"


### PR DESCRIPTION
Refer to [Issue 31](https://github.com/architv/soccer-cli/issues/31)

I think this is a much better way of reading an auth token. 

@architv  For ensuring it reads during PIP installation, you can refer to this link: https://pip.pypa.io/en/latest/user_guide.html#environment-variables