### PR TITLE
Refactor writers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,13 @@ $ pip install soccer-cli
 For building from source, you'll need to get your API key from [here](http://api.football-data.org/register) and create a file `config.py` in the soccer package directory (`soccer/config.py`) with the single line
 ```
 config = {
-    "SOCCER_CLI_API_TOKEN": "<YOUR-API-TOKEN>",
+    "SOCCER_CLI_API_TOKEN": "<YOUR_API_TOKEN>",
 }
+```
+
+An alternate option of storing your API key is to store it as an environment variable. For Linux and Mac OS X, you can do the following:
+```
+export SOCCER_CLI_API_TOKEN="<YOUR_API_TOKEN>"
 ```
 
 ```bash
@@ -44,13 +49,13 @@ Usage
 ### Get standings for a league
 
 ```bash
-$ soccer --standings --league=EPL #EPL is the league code for English Premier League
+$ soccer --standings --league=EPL # EPL is the league code for English Premier League
 ```
 
 ### Get scores for a particular team
 
 ```bash
-$ soccer --team=MUFC #MUFC is the team code for Manchester United
+$ soccer --team=MUFC # MUFC is the team code for Manchester United
 $ soccer --team=PSG --time=10 # scores for all the Paris Saint-Germain games over the past 10 days
 ```
 
@@ -121,4 +126,3 @@ Support
 If you like my work, please support the project by donating.
 
 - https://gratipay.com/~architv
-

--- a/soccer/exceptions.py
+++ b/soccer/exceptions.py
@@ -1,0 +1,2 @@
+class IncorrectParametersException(Exception):
+	pass

--- a/soccer/main.py
+++ b/soccer/main.py
@@ -7,6 +7,8 @@ import sys
 
 import leagueids
 import teamnames
+
+from exceptions import IncorrectParametersException
 from writers import get_writer
 
 
@@ -124,12 +126,20 @@ def get_league_scores(league, time, writer):
                 "See the various team codes listed on README')"))
 @click.option('--time', default=6,
               help="The number of days in the past for which you want to see the scores")
-@click.option('-o', '--output', type=click.Choice(['stdout', 'csv', 'json']),
-              default='stdout',
-              help="Print output in stdout, CSV or JSON format")
-def main(league, time, standings, team, live, output):
+@click.option('--stdout', 'output_format', flag_value='stdout',
+              default=True, help="Print to stdout")
+@click.option('--csv', 'output_format', flag_value='csv',
+               help='Output in CSV format')
+@click.option('--json', 'output_format', flag_value='json',
+              help='Output in JSON format')
+@click.option('-o', '--output-file', default=None,
+              help="Save output to a file (only if csv or json option is provided)")
+def main(league, time, standings, team, live, output_format, output_file):
     """A CLI for live and past football scores from various football leagues"""
-    writer = get_writer(output)
+    if output_format == 'stdout' and output_file:
+        raise IncorrectParametersException('Printing output to stdout and '
+                                           'saving to a file are mutually exclusive')
+    writer = get_writer(output_format, output_file)
 
     if live:
         get_live_scores(writer)

--- a/soccer/main.py
+++ b/soccer/main.py
@@ -70,10 +70,6 @@ def get_team_scores(team, time, writer):
 
 def get_standings(league, writer):
     """Queries the API and gets the standings for a particular league"""
-    if not league:
-        click.secho("Please specify a league. Example --standings --league=EPL",
-                    fg="red", bold=True)
-        return
     league_id = LEAGUE_IDS[league]
     req = requests.get('{base_url}soccerseasons/{id}/leagueTable'.format(
         base_url=BASE_URL, id=league_id), headers=headers)
@@ -136,24 +132,30 @@ def get_league_scores(league, time, writer):
               help="Save output to a file (only if csv or json option is provided)")
 def main(league, time, standings, team, live, output_format, output_file):
     """A CLI for live and past football scores from various football leagues"""
-    if output_format == 'stdout' and output_file:
-        raise IncorrectParametersException('Printing output to stdout and '
-                                           'saving to a file are mutually exclusive')
-    writer = get_writer(output_format, output_file)
+    try:
+        if output_format == 'stdout' and output_file:
+            raise IncorrectParametersException('Printing output to stdout and '
+                                               'saving to a file are mutually exclusive')
+        writer = get_writer(output_format, output_file)
 
-    if live:
-        get_live_scores(writer)
-        return
+        if live:
+            get_live_scores(writer)
+            return
 
-    if standings:
-        get_standings(league, writer)
-        return
+        if standings:
+            if not league:
+                raise IncorrectParametersException('Please specify a league. '
+                                                   'Example --standings --league=EPL')
+            get_standings(league, writer)
+            return
 
-    if team:
-        get_team_scores(team, time, writer)
-        return
+        if team:
+            get_team_scores(team, time, writer)
+            return
 
-    get_league_scores(league, time, writer)
+        get_league_scores(league, time, writer)
+    except IncorrectParametersException as e:
+        click.secho(e.message, fg="red", bold=True)
 
 if __name__ == '__main__':
     main()

--- a/soccer/main.py
+++ b/soccer/main.py
@@ -7,7 +7,7 @@ import sys
 
 import leagueids
 import teamnames
-import writers
+from writers import get_writer
 
 
 BASE_URL = 'http://api.football-data.org/alpha/'
@@ -46,7 +46,7 @@ def get_live_scores(writer):
 
 
 def get_team_scores(team, time, writer):
-    """ Queries the API and gets the particular team scores """
+    """Queries the API and gets the particular team scores"""
     team_id = TEAM_NAMES.get(team, None)
     if team_id:
         req = requests.get('{base_url}teams/{team_id}/fixtures?timeFrame=p{time}'.format(
@@ -67,7 +67,7 @@ def get_team_scores(team, time, writer):
 
 
 def get_standings(league, writer):
-    """ Queries the API and gets the standings for a particular league """
+    """Queries the API and gets the standings for a particular league"""
     if not league:
         click.secho("Please specify a league. Example --standings --league=EPL",
                     fg="red", bold=True)
@@ -83,8 +83,10 @@ def get_standings(league, writer):
 
 
 def get_league_scores(league, time, writer):
-    """Queries the API and fetches the scores for fixtures
-    based upon the league and time parameter"""
+    """
+    Queries the API and fetches the scores for fixtures
+    based upon the league and time parameter
+    """
     if league:
         league_id = LEAGUE_IDS[league]
         req = requests.get('{base_url}soccerseasons/{id}/fixtures?timeFrame=p{time}'.format(
@@ -126,9 +128,8 @@ def get_league_scores(league, time, writer):
               default='stdout',
               help="Print output in stdout, CSV or JSON format")
 def main(league, time, standings, team, live, output):
-    """ A CLI for live and past football scores from various football leagues """
-
-    writer = writers.get_writer(output)
+    """A CLI for live and past football scores from various football leagues"""
+    writer = get_writer(output)
 
     if live:
         get_live_scores(writer)


### PR DESCRIPTION
I have made a few changes in the writers base class. Let me know what you think.

I think i would like your opinion on is too divide the writers into different modules like the following structure:
soccer/
    soccer/
        writers/
            writer.py -> class BaseWriter would move here
            stdout_writer.py
            csv_writer.py
            json_writer.py

If we do this then the function get_writer (from writers.py) can be moved to main.py and it will be something like this in main.py:
```python
from writers imprt Stdout, Csv Json
....
....
def get_writer(output):
    return globals()[output.capitalize()]()
```