### PR TITLE
Fix unicode issue with json and csv output

### DIFF
--- a/soccer/writers.py
+++ b/soccer/writers.py
@@ -167,11 +167,13 @@ class Csv(BaseWriter):
     def generate_output(self, result):
         if not self.output_filename:
             for row in result:
-                click.echo(','.join(str(item) for item in row))
+                click.echo(u','.join(unicode(item) for item in row))
         else:
             with open(self.output_filename, 'w') as csv_file:
                 writer = csv.writer(csv_file)
                 for row in result:
+                    row = [unicode(s) for s in row]
+                    row = [s.encode('utf-8') for s in row]
                     writer.writerow(row)
 
     def live_scores(self, live_scores):

--- a/soccer/writers.py
+++ b/soccer/writers.py
@@ -2,6 +2,7 @@ import click
 import csv
 import datetime
 import json
+import io
 
 import leagueids
 import leagueproperties
@@ -223,10 +224,11 @@ class Json(BaseWriter):
 
     def generate_output(self, result):
         if not self.output_filename:
-            click.echo(json.dumps(result, indent=4, separators=(',', ': ')))
+            click.echo(json.dumps(result, indent=4, separators=(',', ': '), ensure_ascii=False))
         else:
-            with open(self.output_filename, 'w') as json_file:
-                json.dump(result, json_file, indent=4, separators=(',', ': '))
+            with io.open(self.output_filename, 'w', encoding='utf-8') as json_file:
+                data = json.dumps(result, json_file, indent=4, separators=(',', ': '), ensure_ascii=False)
+                json_file.write(data)
 
     def live_scores(self, live_scores):
         """Store output of live scores to a JSON file"""

--- a/soccer/writers.py
+++ b/soccer/writers.py
@@ -172,8 +172,7 @@ class Csv(BaseWriter):
             with open(self.output_filename, 'w') as csv_file:
                 writer = csv.writer(csv_file)
                 for row in result:
-                    row = [unicode(s) for s in row]
-                    row = [s.encode('utf-8') for s in row]
+                    row = [unicode(s).encode('utf-8') for s in row]
                     writer.writerow(row)
 
     def live_scores(self, live_scores):


### PR DESCRIPTION
For `--json`
It previously printed like this:
`"awayTeamName": "1. FC K\u00f6ln"`
But we want:
   ` "awayTeamName": "1. FC Köln"`

And with `--csv` it just did not work for a team that had a special character.

`UnicodeEncodeError: 'ascii' codec can't encode character u'\xfc' in position 11: ordinal not in range(128)`

The Python 2 CSV library is pretty unhelpful when it comes to unicode. At least by default.

Seemed simpler to just go element by element and make sure and encode it appropriately.

During the fix I noticed I had a familiar issue on Windows where it doesn't print a unicode character properly:

```
$ python -c "print 'Köln'"
$ K÷ln
$
$ python -c "print u'Köln'"
$ Köln
```

This PR sorts that issue too though.

**Before:**
```
$ soccer --league BL --json
{
    "league_scores": [
        {
            "league": "BL",
            "homeTeamName": "FC Bayern M\u00fcnchen",
            "goalsAwayTeam": 1,
            "awayTeamName": "FC Augsburg",
            "goalsHomeTeam": 2
        },
```
**After:**
```
$ soccer --league BL --json
{
    "league_scores": [
        {
            "league": "BL",
            "homeTeamName": "FC Bayern München",
            "goalsAwayTeam": 1,
            "awayTeamName": "FC Augsburg",
            "goalsHomeTeam": 2
        },
```