### PR TITLE
Use explicit relative imports

### DIFF
--- a/soccer/main.py
+++ b/soccer/main.py
@@ -3,9 +3,9 @@ import os
 import requests
 import sys
 
-from . import leagueids, teamnames
-from .exceptions import IncorrectParametersException
-from .writers import get_writer
+from soccer import leagueids, teamnames
+from soccer.exceptions import IncorrectParametersException
+from soccer.writers import get_writer
 
 
 BASE_URL = 'http://api.football-data.org/alpha/'
@@ -16,7 +16,7 @@ TEAM_NAMES = teamnames.team_names
 try:
     api_token = os.environ['SOCCER_CLI_API_TOKEN']
 except KeyError:
-    from .config import config
+    from soccer.config import config
     api_token = config.get('SOCCER_CLI_API_TOKEN')
 
 if not api_token:

--- a/soccer/main.py
+++ b/soccer/main.py
@@ -3,11 +3,9 @@ import os
 import requests
 import sys
 
-import leagueids
-import teamnames
-
-from soccer.exceptions import IncorrectParametersException
-from writers import get_writer
+from . import leagueids, teamnames
+from .exceptions import IncorrectParametersException
+from .writers import get_writer
 
 
 BASE_URL = 'http://api.football-data.org/alpha/'
@@ -18,7 +16,7 @@ TEAM_NAMES = teamnames.team_names
 try:
     api_token = os.environ['SOCCER_CLI_API_TOKEN']
 except KeyError:
-    from config import config
+    from .config import config
     api_token = config.get('SOCCER_CLI_API_TOKEN')
 
 if not api_token:

--- a/soccer/writers.py
+++ b/soccer/writers.py
@@ -4,12 +4,11 @@ import datetime
 import json
 import io
 
-import leagueids
-import leagueproperties
-
 from abc import ABCMeta, abstractmethod
 from itertools import groupby
 from collections import namedtuple
+
+from . import leagueids, leagueproperties
 
 LEAGUE_PROPERTIES = leagueproperties.LEAGUE_PROPERTIES
 LEAGUE_IDS = leagueids.LEAGUE_IDS

--- a/soccer/writers.py
+++ b/soccer/writers.py
@@ -8,7 +8,7 @@ from abc import ABCMeta, abstractmethod
 from itertools import groupby
 from collections import namedtuple
 
-from . import leagueids, leagueproperties
+from soccer import leagueids, leagueproperties
 
 LEAGUE_PROPERTIES = leagueproperties.LEAGUE_PROPERTIES
 LEAGUE_IDS = leagueids.LEAGUE_IDS


### PR DESCRIPTION
Bad idea to use the old relative imports since if you have a duplicate
name somewhere in your module path it might try and import the wrong
module causing an error.