### PR TITLE
Fix team output crash

### DIFF
--- a/soccer/writers.py
+++ b/soccer/writers.py
@@ -125,8 +125,7 @@ class Stdout(BaseWriter):
             if team["goalDifference"] >= 0:
                 team["goalDifference"] = ' ' + str(team["goalDifference"])
             if LEAGUE_PROPERTIES[league]["cl"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["cl"][1]:
-                click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" %
-                            (
+                click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" % (
                             team["position"],
                             team["teamName"],
                             team["playedGames"],
@@ -135,8 +134,7 @@ class Stdout(BaseWriter):
                             ),
                             bold=True, fg=self.colors.CL_POSITION)
             elif LEAGUE_PROPERTIES[league]["el"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["el"][1]:
-                click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" %
-                            (
+                click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" % (
                             team["position"],
                             team["teamName"],
                             team["playedGames"],
@@ -145,8 +143,7 @@ class Stdout(BaseWriter):
                             ),
                             fg=self.colors.EL_POSITION)
             elif LEAGUE_PROPERTIES[league]["rl"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["rl"][1]:  # 5-15 in BL, 5-17 in others
-                click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" %
-                            (
+                click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" % (
                             team["position"],
                             team["teamName"],
                             team["playedGames"],
@@ -155,15 +152,14 @@ class Stdout(BaseWriter):
                             ),
                             fg=self.colors.RL_POSITION)
             else:
-                click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" %
-                            (
-                            team["position"],
-                            team["teamName"],
-                            team["playedGames"],
-                            team["goalDifference"],
-                            team["points"]
-                            ),
-                            fg=self.colors.POSITION)
+                click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" % (
+                           team["position"],
+                           team["teamName"],
+                           team["playedGames"],
+                           team["goalDifference"],
+                           team["points"]
+                           ),
+                           fg=self.colors.POSITION)
 
     def league_scores(self, total_data, time):
         """Prints the data in a pretty format"""

--- a/soccer/writers.py
+++ b/soccer/writers.py
@@ -126,23 +126,43 @@ class Stdout(BaseWriter):
                 team["goalDifference"] = ' ' + str(team["goalDifference"])
             if LEAGUE_PROPERTIES[league]["cl"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["cl"][1]:
                 click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" %
-                            (str(team["position"]), team["teamName"],
-                             str(team["playedGames"]), team["goalDifference"], str(team["points"])),
+                            (
+                            team["position"],
+                            team["teamName"],
+                            team["playedGames"],
+                            team["goalDifference"],
+                            team["points"]
+                            ),
                             bold=True, fg=self.colors.CL_POSITION)
             elif LEAGUE_PROPERTIES[league]["el"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["el"][1]:
                 click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" %
-                            (str(team["position"]), team["teamName"],
-                             str(team["playedGames"]), team["goalDifference"], str(team["points"])),
+                            (
+                            team["position"],
+                            team["teamName"],
+                            team["playedGames"],
+                            team["goalDifference"],
+                            team["points"]
+                            ),
                             fg=self.colors.EL_POSITION)
             elif LEAGUE_PROPERTIES[league]["rl"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["rl"][1]:  # 5-15 in BL, 5-17 in others
                 click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" %
-                            (str(team["position"]), team["teamName"],
-                             str(team["playedGames"]), team["goalDifference"], str(team["points"])),
+                            (
+                            team["position"],
+                            team["teamName"],
+                            team["playedGames"],
+                            team["goalDifference"],
+                            team["points"]
+                            ),
                             fg=self.colors.RL_POSITION)
             else:
                 click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" %
-                            (str(team["position"]), team["teamName"],
-                             str(team["playedGames"]), team["goalDifference"], str(team["points"])),
+                            (
+                            team["position"],
+                            team["teamName"],
+                            team["playedGames"],
+                            team["goalDifference"],
+                            team["points"]
+                            ),
                             fg=self.colors.POSITION)
 
     def league_scores(self, total_data, time):

--- a/soccer/writers.py
+++ b/soccer/writers.py
@@ -106,9 +106,14 @@ class Stdout(BaseWriter):
         for player in players:
             click.echo()
             click.secho("%-4s %-25s    %-20s    %-20s    %-15s    %-10s" % 
-                        (str(player["jerseyNumber"]), player["name"].encode('utf-8'), player["position"].encode('utf-8'), 
-                            player["nationality"].encode('utf-8'), player["dateOfBirth"].encode('utf-8'), 
-                            str(player["marketValue"].encode('utf-8'))), bold=True)
+                        (player["jerseyNumber"],
+                            player["name"],
+                            player["position"],
+                            player["nationality"],
+                            player["dateOfBirth"],
+                            player["marketValue"]),
+                            bold=True
+                            )
 
 
     def standings(self, league_table, league):


### PR DESCRIPTION
Fixed a crash when a player had a market value of `null`.

```bash
$ python -m soccer.main --team AFC --players
...
...
AttributeError: 'NoneType' object has no attribute 'encode'
```
Removed all of the other `str` encoding stuff as it works just the same without it? I have tested on Windows too. Although Windows cmd cannot display the € symbol. But I don't know what can be done about that. Using this terminal https://mintty.github.io I was able to display the character just fine.



When using the string mod operator I do not think there is any need to do `str(some_number)`.

Also cleaned up the formatting around the mod format strings. It was really difficult to work with when they are all squashed up.