### PR TITLE
Improved handling of API request status codes

### DIFF
--- a/soccer/exceptions.py
+++ b/soccer/exceptions.py
@@ -1,3 +1,6 @@
 class IncorrectParametersException(Exception):
-	pass
-	
+    pass
+
+
+class APIErrorException(Exception):
+    pass


### PR DESCRIPTION
This handles dealing with http status codes once instead of having to deal with them on every single api calling function.

Uses new `_get` function that wraps `requests.get`. This is just for making calls to `api.football-data.org` as you will notice the `get_live_scores` function remains untouched as it is a different API.

Every function should have the same effect mostly. Just instead of checking if the `status_code` is `ok` on each function, it now checks it once.

Also instead of composing the `base_url` + `headers=headers` on each function, it will just do this once.


This should make the api functions a bit cleaner and easier to test. Not all api calling situations are correctly accounted for but this is a step in the right direction in my opinion.