### PR TITLE
Change conditional to be more readable

### DIFF
--- a/soccer/writers.py
+++ b/soccer/writers.py
@@ -123,7 +123,18 @@ class Stdout(BaseWriter):
         for team in league_table["standing"]:
             if team["goalDifference"] >= 0:
                 team["goalDifference"] = ' ' + str(team["goalDifference"])
-            if LEAGUE_PROPERTIES[league]["cl"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["cl"][1]:
+
+            # Define the upper and lower bounds for Champions League,
+            # Europa League and Relegation places.
+            # This is so we can highlight them appropriately.
+            cl_upper = LEAGUE_PROPERTIES[league]['cl'][0]
+            cl_lower = LEAGUE_PROPERTIES[league]['cl'][1]
+            el_upper = LEAGUE_PROPERTIES[league]['el'][0]
+            el_lower = LEAGUE_PROPERTIES[league]['el'][1]
+            rl_upper = LEAGUE_PROPERTIES[league]['rl'][0]
+            rl_lower = LEAGUE_PROPERTIES[league]['rl'][1]
+
+            if cl_upper <= team["position"] <= cl_lower:
                 click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" % (
                             team["position"],
                             team["teamName"],
@@ -132,7 +143,7 @@ class Stdout(BaseWriter):
                             team["points"]
                             ),
                             bold=True, fg=self.colors.CL_POSITION)
-            elif LEAGUE_PROPERTIES[league]["el"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["el"][1]:
+            elif el_upper <= team["position"] <= el_lower:
                 click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" % (
                             team["position"],
                             team["teamName"],
@@ -141,7 +152,7 @@ class Stdout(BaseWriter):
                             team["points"]
                             ),
                             fg=self.colors.EL_POSITION)
-            elif LEAGUE_PROPERTIES[league]["rl"][0] <= team["position"] <= LEAGUE_PROPERTIES[league]["rl"][1]:  # 5-15 in BL, 5-17 in others
+            elif rl_upper <= team["position"] <= rl_lower:
                 click.secho("%-6s  %-30s    %-9s    %-11s    %-10s" % (
                             team["position"],
                             team["teamName"],


### PR DESCRIPTION
Really long conditionals are hard to read in my opinion. This sets all the league position properties into variables with short names and uses those instead.

This makes the conditional lines quite short and I think possibly makes it more clear what the purpose is.

The conditional line went from about 109 characters across to ~57.

I think this works better than splitting the conditionals into multiple lines.