### PR TITLE
Converts UTC time string to the local user time in console

### DIFF
--- a/soccer/main.py
+++ b/soccer/main.py
@@ -50,7 +50,7 @@ def _get(url):
         raise APIErrorException('You have exceeded your allowed requests per minute/day')
 
 
-def get_live_scores(writer):
+def get_live_scores(writer, use_12_hour_format):
     """Gets the live scores"""
     req = requests.get(LIVE_URL)
     if req.status_code == requests.codes.ok:
@@ -58,7 +58,7 @@ def get_live_scores(writer):
         if len(scores["games"]) == 0:
             click.secho("No live action currently", fg="red", bold=True)
             return
-        writer.live_scores(scores)
+        writer.live_scores(scores, use_12_hour_format)
     else:
         click.secho("There was problem getting live scores", fg="red", bold=True)
 
@@ -149,6 +149,7 @@ def get_team_players(team, writer):
 
 @click.command()
 @click.option('--live', is_flag=True, help="Shows live scores from various leagues")
+@click.option('--use12hour', is_flag=True, default=False, help="Displays the time using 12 hour format instead of 24 (default).")
 @click.option('--standings', is_flag=True, help="Standings for a particular league")
 @click.option('--league', '-league', type=click.Choice(LEAGUE_IDS.keys()),
               help=("Choose the league whose fixtures you want to see. "
@@ -167,7 +168,7 @@ def get_team_players(team, writer):
               help='Output in JSON format')
 @click.option('-o', '--output-file', default=None,
               help="Save output to a file (only if csv or json option is provided)")
-def main(league, time, standings, team, live, players, output_format, output_file):
+def main(league, time, standings, team, live, use12hour, players, output_format, output_file):
     """A CLI for live and past football scores from various football leagues"""
     try:
         if output_format == 'stdout' and output_file:
@@ -176,7 +177,7 @@ def main(league, time, standings, team, live, players, output_format, output_fil
         writer = get_writer(output_format, output_file)
 
         if live:
-            get_live_scores(writer)
+            get_live_scores(writer, use12hour)
             return
 
         if standings:

--- a/soccer/writers.py
+++ b/soccer/writers.py
@@ -85,7 +85,7 @@ class Stdout(BaseWriter):
             self.league_header(league)
             for game in games:
                 self.scores(self.parse_result(game), add_new_line=False)
-                click.secho('   %s' % self.convert_utc_to_local_time(game["time"]), fg=self.colors.TIME)
+                click.secho('   %s' % Stdout.convert_utc_to_local_time(game["time"]), fg=self.colors.TIME)
                 click.echo()
 
     def team_scores(self, team_scores, time):
@@ -212,7 +212,8 @@ class Stdout(BaseWriter):
 
         return result
 
-    def convert_utc_to_local_time(self, time_str):
+    @staticmethod
+    def convert_utc_to_local_time(time_str):
         """Converts the API UTC time string to the local user time."""
         if not time_str.endswith(" UTC"):
            return time_str

--- a/soccer/writers.py
+++ b/soccer/writers.py
@@ -78,14 +78,15 @@ class Stdout(BaseWriter):
         )
         self.colors = type('Enum', (), enums)
 
-    def live_scores(self, live_scores):
+    def live_scores(self, live_scores, use_12_hour_format):
         """Prints the live scores in a pretty format"""
         scores = sorted(live_scores["games"], key=lambda x: x["league"])
         for league, games in groupby(scores, key=lambda x: x["league"]):
             self.league_header(league)
             for game in games:
                 self.scores(self.parse_result(game), add_new_line=False)
-                click.secho('   %s' % Stdout.convert_utc_to_local_time(game["time"]), fg=self.colors.TIME)
+                click.secho('   %s' % Stdout.convert_utc_to_local_time(game["time"], use_12_hour_format),
+                            fg=self.colors.TIME)
                 click.echo()
 
     def team_scores(self, team_scores, time):
@@ -213,17 +214,24 @@ class Stdout(BaseWriter):
         return result
 
     @staticmethod
-    def convert_utc_to_local_time(time_str):
+    def convert_utc_to_local_time(time_str, use_12_hour_format):
         """Converts the API UTC time string to the local user time."""
         if not time_str.endswith(" UTC"):
            return time_str
 
+        today_utc = datetime.datetime.utcnow()
+        utc_local_diff = today_utc - datetime.datetime.now()
+        
         time_str, _ = time_str.split(" UTC")
         utc_time = datetime.datetime.strptime(time_str,'%I:%M %p')
-        utc_local_diff = datetime.datetime.utcnow() - datetime.datetime.now()
-        local_time = utc_time - utc_local_diff
-
-        return datetime.datetime.strftime(local_time,'%I:%M %p')
+        utc_datetime = datetime.datetime(today_utc.year, today_utc.month, today_utc.day,
+                                         utc_time.hour, utc_time.minute)
+        local_time = utc_datetime - utc_local_diff
+        
+        if use_12_hour_format:
+            return datetime.datetime.strftime(local_time,'%I:%M %p')
+        else:
+            return datetime.datetime.strftime(local_time,'%H:%M')
 
 
 class Csv(BaseWriter):

--- a/soccer/writers.py
+++ b/soccer/writers.py
@@ -85,7 +85,7 @@ class Stdout(BaseWriter):
             self.league_header(league)
             for game in games:
                 self.scores(self.parse_result(game), add_new_line=False)
-                click.secho('   %s' % game["time"], fg=self.colors.TIME)
+                click.secho('   %s' % self.convert_utc_to_local_time(game["time"]), fg=self.colors.TIME)
                 click.echo()
 
     def team_scores(self, team_scores, time):
@@ -211,6 +211,18 @@ class Stdout(BaseWriter):
                 valid_score(data["goalsAwayTeam"]))
 
         return result
+
+    def convert_utc_to_local_time(self, time_str):
+        """Converts the API UTC time string to the local user time."""
+        if not time_str.endswith(" UTC"):
+           return time_str
+
+        time_str, _ = time_str.split(" UTC")
+        utc_time = datetime.datetime.strptime(time_str,'%I:%M %p')
+        utc_local_diff = datetime.datetime.utcnow() - datetime.datetime.now()
+        local_time = utc_time - utc_local_diff
+
+        return datetime.datetime.strftime(local_time,'%I:%M %p')
 
 
 class Csv(BaseWriter):


### PR DESCRIPTION
For live matches, the time for the match is in UTC, which makes sense for an API. However when printing it out to the console, UTC doesn't make much sense since you have to force the user to covert it to their local time. 

So instead of printing:
=================== UEFA Champions League ====================
Arsenal                    -  vs  -                 Barcelona   7:45 PM UTC
Juventus                   -  vs  -             Bayern Munich   7:45 PM UTC

It's now localized to the user (in this case, me :smile: ):
=================== UEFA Champions League ====================
Arsenal                    -  vs  -                 Barcelona   11:45 AM
Juventus                   -  vs  -             Bayern Munich   11:45 AM
