### PR TITLE
Add team name to team code list

### DIFF
--- a/soccer/main.py
+++ b/soccer/main.py
@@ -165,7 +165,21 @@ def map_team_id(code):
         click.secho("No team found for this code", fg="red", bold=True)
 
 
+def list_team_codes():
+    """List team names in alphabetical order of team ID."""
+    teamcodes = sorted(TEAM_NAMES.keys())
+    here = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(here, "teamcodes.json")) as jfile:
+        data = json.load(jfile)
+    for code in teamcodes:
+        for key, value in data.iteritems():
+            if value == code:
+                print(u"{0}: {1}".format(value, key))
+                break
+
+
 @click.command()
+@click.option('--list', 'listcodes', is_flag=True, help="List all valid team code/team name pairs")
 @click.option('--live', is_flag=True, help="Shows live scores from various leagues")
 @click.option('--use12hour', is_flag=True, default=False, help="Displays the time using 12 hour format instead of 24 (default).")
 @click.option('--standings', is_flag=True, help="Standings for a particular league")
@@ -188,13 +202,17 @@ def map_team_id(code):
               help='Output in JSON format')
 @click.option('-o', '--output-file', default=None,
               help="Save output to a file (only if csv or json option is provided)")
-def main(league, time, standings, team, live, use12hour, players, output_format, output_file, upcoming, lookup):
+def main(league, time, standings, team, live, use12hour, players, output_format, output_file, upcoming, lookup, listcodes):
     """A CLI for live and past football scores from various football leagues"""
     try:
         if output_format == 'stdout' and output_file:
             raise IncorrectParametersException('Printing output to stdout and '
                                                'saving to a file are mutually exclusive')
         writer = get_writer(output_format, output_file)
+
+        if listcodes:
+            list_team_codes()
+            return
 
         if live:
             get_live_scores(writer, use12hour)


### PR DESCRIPTION
Fix #69, again.

    $ soccer --list
    ACM: AC Milan
    AFC: Arsenal FC
    AFCB: AFC Bournemouth
    ATM: Club Atlético de Madrid
    AVFC: Aston Villa FC
    B04: Bayer Leverkusen
    BIL: Athletic Club
    BM: FC Bayern München
    BMG: Bor. Mönchengladbach
    BOR: FC Girondins de Bordeaux
    BSC: Hertha BSC
    BVB: Borussia Dortmund
    CFC: Chelsea FC
    etc.

It's not as intuitive as entering a team name and getting the exact code, but with this we don't need to deal with synonyms, special characters, abbreviations, etc.