### PR TITLE
Add preceding dot to soccer-cli.ini filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ $ cd soccer-cli
 $ python setup.py install
 ```
 
-You can set the API key using an environment variable as shown above or create a file `soccer-cli.ini` in your home folder (`/home/username/soccer-cli.ini`) that contains only your API token, such that:
+You can set the API key using an environment variable as shown above or create a file `.soccer-cli.ini` in your home folder (`/home/username/.soccer-cli.ini`) that contains only your API token, such that:
 
 ```bash
-$ cat /home/username/soccer-cli.ini
+$ cat /home/username/.soccer-cli.ini
 <YOUR_API_TOKEN>
 ```
 

--- a/soccer/main.py
+++ b/soccer/main.py
@@ -53,7 +53,7 @@ def load_config_key():
         api_token = os.environ['SOCCER_CLI_API_TOKEN']
     except KeyError:
         home = os.path.expanduser("~")
-        config = os.path.join(home, "soccer-cli.ini")
+        config = os.path.join(home, ".soccer-cli.ini")
         if not os.path.exists(config):
             with open(config, "w") as cfile:
                 key = get_input_key()


### PR DESCRIPTION
The `soccer-cli.ini` file should have a dot preceding it so that file explorers and the `ls` command will not display it by default.

Windows still displays dotfiles unfortunately unless you make use of this http://superuser.com/a/366883

Also it really isn't an `ini` file. It could be named `.soccer-cli-apikey`. Unless there may be more configuration settings recorded here in the future.