### PR TITLE
Update --time option description

### DIFF
--- a/soccer/main.py
+++ b/soccer/main.py
@@ -239,7 +239,7 @@ def list_team_codes():
 @click.option('--lookup', is_flag=True,
               help="Get full team name from team code when used with --team command.")
 @click.option('--time', default=6,
-              help="The number of days in the past for which you want to see the scores.")
+              help="The number of days in the past for which you want to see the scores, or the number of days in the future when used with --upcoming")
 @click.option('--upcoming', is_flag=True, default=False,
               help="Displays upcoming games when used with --time command.")
 @click.option('--stdout', 'output_format', flag_value='stdout', default=True,


### PR DESCRIPTION
When looking for upcoming matches, I was confused by the `--time` options, because the `--upcoming` option says 

> --upcoming                      Displays upcoming games when used with --time command.

But "upcoming" and "in the past" does not sound right.
