### PR TITLE
Fix whitespace issues and removed unused imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 *.pyc
 config.py
 README

--- a/soccer/main.py
+++ b/soccer/main.py
@@ -1,16 +1,14 @@
-import click
 import os
-import requests
 import sys
 import json
 
+import click
+
 from soccer import leagueids
-from soccer.exceptions import IncorrectParametersException, APIErrorException
+from soccer.exceptions import IncorrectParametersException
 from soccer.writers import get_writer
+from soccer.request_handler import RequestHandler
 
-from request_handler import RequestHandler
-
-LEAGUE_IDS = leagueids.LEAGUE_IDS
 
 def load_json(file):
     """Load JSON file at app start"""
@@ -20,6 +18,7 @@ def load_json(file):
     return data
 
 
+LEAGUE_IDS = leagueids.LEAGUE_IDS
 TEAM_DATA = load_json("teams.json")["teams"]
 TEAM_NAMES = {team["code"]: team["id"] for team in TEAM_DATA}
 
@@ -71,6 +70,7 @@ def load_config_key():
             sys.exit(1)
     return api_token
 
+
 def map_team_id(code):
     """Take in team ID, read JSON file to map ID to name"""
     for team in TEAM_DATA:
@@ -116,7 +116,9 @@ def list_team_codes():
 @click.option('--lookup', is_flag=True,
               help="Get full team name from team code when used with --team command.")
 @click.option('--time', default=6,
-              help="The number of days in the past for which you want to see the scores, or the number of days in the future when used with --upcoming")
+              help=("The number of days in the past for which you "
+                    "want to see the scores, or the number of days "
+                    "in the future when used with --upcoming"))
 @click.option('--upcoming', is_flag=True, default=False,
               help="Displays upcoming games when used with --time command.")
 @click.option('--stdout', 'output_format', flag_value='stdout', default=True,
@@ -127,8 +129,8 @@ def list_team_codes():
               help='Output in JSON format.')
 @click.option('-o', '--output-file', default=None,
               help="Save output to a file (only if csv or json option is provided).")
-def main(league, time, standings, team, live, use12hour, players, output_format,
-         output_file, upcoming, lookup, listcodes, apikey):
+def main(league, time, standings, team, live, use12hour, players,
+         output_format, output_file, upcoming, lookup, listcodes, apikey):
     """
     A CLI for live and past football scores from various football leagues.
 
@@ -187,6 +189,7 @@ def main(league, time, standings, team, live, use12hour, players, output_format,
         rh.get_league_scores(league, time, upcoming, use12hour)
     except IncorrectParametersException as e:
         click.secho(e.message, fg="red", bold=True)
+
 
 if __name__ == '__main__':
     main()

--- a/soccer/request_handler.py
+++ b/soccer/request_handler.py
@@ -1,6 +1,7 @@
 import requests
 import click
-from soccer.exceptions import IncorrectParametersException, APIErrorException
+from soccer.exceptions import APIErrorException
+
 
 class RequestHandler(object):
 
@@ -32,7 +33,6 @@ class RequestHandler(object):
         if req.status_code == requests.codes.too_many_requests:
             raise APIErrorException('You have exceeded your allowed requests per minute/day')
 
-
     def get_live_scores(self, use_12_hour_format):
         """Gets the live scores"""
         req = requests.get(RequestHandler.LIVE_URL)
@@ -44,7 +44,6 @@ class RequestHandler(object):
             self.writer.live_scores(scores, use_12_hour_format)
         else:
             click.secho("There was problem getting live scores", fg="red", bold=True)
-
 
     def get_team_scores(self, team, time, show_upcoming, use_12_hour_format):
         """Queries the API and gets the particular team scores"""
@@ -67,7 +66,6 @@ class RequestHandler(object):
             click.secho("Team code is not correct.",
                         fg="red", bold=True)
 
-
     def get_standings(self, league):
         """Queries the API and gets the standings for a particular league"""
         league_id = self.league_ids[league]
@@ -80,7 +78,6 @@ class RequestHandler(object):
             # if that league does not have standings available. ie. Champions League
             click.secho("No standings availble for {league}.".format(league=league),
                         fg="red", bold=True)
-
 
     def get_league_scores(self, league, time, show_upcoming, use_12_hour_format):
 
@@ -100,7 +97,9 @@ class RequestHandler(object):
                     click.secho("No {league} matches in the past week.".format(league=league),
                                 fg="red", bold=True)
                     return
-                self.writer.league_scores(fixtures_results, time, show_upcoming, use_12_hour_format)
+                self.writer.league_scores(fixtures_results,
+                                          time, show_upcoming,
+                                          use_12_hour_format)
             except APIErrorException:
                 click.secho("No data for the given league.", fg="red", bold=True)
         else:
@@ -109,10 +108,12 @@ class RequestHandler(object):
                 req = self._get('fixtures?timeFrame={time_frame}{time}'.format(
                      time_frame=time_frame, time=str(time)))
                 fixtures_results = req.json()
-                self.writer.league_scores(fixtures_results, time, show_upcoming, use_12_hour_format)
+                self.writer.league_scores(fixtures_results,
+                                          time,
+                                          show_upcoming,
+                                          use_12_hour_format)
             except APIErrorException:
                 click.secho("No data available.", fg="red", bold=True)
-
 
     def get_team_players(self, team):
         """
@@ -131,4 +132,3 @@ class RequestHandler(object):
         except APIErrorException:
             click.secho("No data for the team. Please check the team code.",
                         fg="red", bold=True)
-

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -1,9 +1,12 @@
 import unittest
 import sys
+
 sys.path.append('soccer')
-import leagueproperties
-import leagueids
-from main import load_json
+
+from soccer import leagueproperties
+from soccer import leagueids
+from soccer.main import load_json
+
 
 class TestLoadData(unittest.TestCase):
 
@@ -40,6 +43,7 @@ class TestLoadData(unittest.TestCase):
         except AttributeError:
             raised = True
         self.assertFalse(raised)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Remove unused imports, fixed a couple of lines that were too long...

Use absolute imports in test file.

There should be two blank lines between functions and a single blank line for class methods.

Also from PEP8:
```
Imports should be grouped in the following order:

- standard library imports
- related third party imports
- local application/library specific imports

You should put a blank line between each group of imports.
```