### PR TITLE
Implement some tests for request handler

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ argparse==1.2.1
 click==5.0
 requests==2.7.0
 wsgiref==0.1.2
+mock==1.0.1

--- a/tests/mock_response.py
+++ b/tests/mock_response.py
@@ -1,0 +1,7 @@
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_data

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -19,30 +19,23 @@ class TestLoadData(unittest.TestCase):
         pass
 
     def test_load_team_data(self):
-        raised = False
         try:
             load_json(TestLoadData.TEAMS_INFO_FILENAME)["teams"]
         except IOError:
-            raised = True
-        self.assertFalse(raised)
+            self.fail("File doesn't exist!")
 
     def test_load_league_properties(self):
-        raised = False
         try:
             league_properties = leagueproperties.LEAGUE_PROPERTIES
-            league_properties.keys()
         except AttributeError:
-            raised = True
-        self.assertFalse(raised)
+            self.fail("File doesn't exist!")
 
     def test_load_league_ids(self):
-        raised = False
         try:
             leage_ids = leagueids.LEAGUE_IDS
             leage_ids.keys()
         except AttributeError:
-            raised = True
-        self.assertFalse(raised)
+            self.fail("File doesn't exist!")
 
 
 if __name__ == '__main__':

--- a/tests/test_request_handler.py
+++ b/tests/test_request_handler.py
@@ -1,0 +1,168 @@
+import os
+import sys
+sys.path.append('soccer')
+import json
+import requests
+import unittest
+import leagueids
+import mock
+import click
+from main import load_json
+from mock_response import MockResponse
+from soccer.exceptions import APIErrorException
+from request_handler import RequestHandler
+from soccer.writers import get_writer
+from soccer.writers import Stdout
+
+
+def mocked_requests_get(*args, **kwargs):
+    return MockResponse(args[0], int(args[1]))
+
+
+def get_team_data():
+    here = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(here, "../soccer/teams.json")) as jfile:
+        data = json.load(jfile)
+    return data
+
+
+class TestRequestHandler(unittest.TestCase):
+
+    def setUp(self):
+        dummy_key = 12345678901234567890123456789012
+        headers = {'X-Auth-Token': dummy_key}
+        TEAM_DATA = get_team_data()["teams"]
+        TEAM_NAMES = {team["code"]: team["id"] for team in TEAM_DATA}
+        LEAGUE_IDS = leagueids.LEAGUE_IDS
+        self.dummy_url = "http://some_url"
+        writer = get_writer()
+        self.rq = RequestHandler(headers, LEAGUE_IDS, TEAM_NAMES, writer)
+
+    def tearDown(self):
+        pass
+
+    @mock.patch('requests.get')
+    def test_ok_code(self, mock_call):
+        mock_call.return_value = mock.MagicMock(
+                status_code=requests.codes.ok,
+                response=json.dumps({'key': 'value'}))
+        raised = False
+        try:
+            self.rq._get(self.dummy_url)
+        except APIErrorException:
+            raised = True
+        self.assertFalse(raised is True)
+
+    @mock.patch('requests.get')
+    def test_bad_code(self, mock_call):
+        mock_call.return_value = mock.MagicMock(
+                status_code=requests.codes.bad,
+                response=json.dumps({'key': 'value'}))
+        raised = False
+        try:
+            self.rq._get(self.dummy_url)
+        except APIErrorException:
+            raised = True
+        self.assertTrue(raised is True)
+
+    @mock.patch('requests.get')
+    def test_forbidden_code(self, mock_call):
+        mock_call.return_value = mock.MagicMock(
+                status_code=requests.codes.forbidden,
+                response=json.dumps({'key': 'value'}))
+        raised = False
+        try:
+            self.rq._get(self.dummy_url)
+        except APIErrorException:
+            raised = True
+        self.assertTrue(raised is True)
+
+    @mock.patch('requests.get')
+    def test_not_found_code(self, mock_call):
+        mock_call.return_value = mock.MagicMock(
+                status_code=requests.codes.not_found,
+                response=json.dumps({'key': 'value'}))
+        raised = False
+        try:
+            self.rq._get(self.dummy_url)
+        except APIErrorException:
+            raised = True
+        self.assertTrue(raised is True)
+
+    @mock.patch('requests.get')
+    def test_too_many_requests_code(self, mock_call):
+        mock_call.return_value = mock.MagicMock(
+                status_code=requests.codes.too_many_requests,
+                response=json.dumps({'key': 'value'}))
+        raised = False
+        try:
+            self.rq._get(self.dummy_url)
+        except APIErrorException:
+            raised = True
+        self.assertTrue(raised is True)
+
+    @mock.patch('test_request_handler.Stdout.live_scores')
+    @mock.patch('requests.get')
+    def test_get_live_scores_ok(self, mock_request_call, mock_writer):
+        mock_request_call.side_effect = [mocked_requests_get({'games': [1, 2]}, 200)]
+        mock_writer.return_value = mock.Mock()
+        self.rq.get_live_scores(True)
+        mock_writer.assert_called_once()
+
+    @mock.patch('test_request_handler.click.secho')
+    @mock.patch('test_request_handler.Stdout.live_scores')
+    @mock.patch('requests.get')
+    def test_get_live_scores_0_games(self,
+                                     mock_request_call, mock_writer,
+                                     mock_click):
+        mock_request_call.side_effect = [mocked_requests_get({'games': []}, 200)]
+        mock_writer.return_value = mock.Mock()
+        self.rq.get_live_scores(True)
+        mock_click.assert_called_with("No live action currently", fg="red", bold=True)
+
+    @mock.patch('test_request_handler.click.secho')
+    @mock.patch('test_request_handler.Stdout.live_scores')
+    @mock.patch('requests.get')
+    def test_get_live_scores_error(self,
+                                   mock_request_call, mock_writer,
+                                   mock_click):
+        mock_request_call.side_effect = [mocked_requests_get({'games': [1, 2]}, 400)]
+        mock_writer.return_value = mock.Mock()
+        self.rq.get_live_scores(True)
+        mock_click.assert_called_with("There was problem getting live scores", fg="red", bold=True)
+
+    @mock.patch('test_request_handler.Stdout.team_scores')
+    @mock.patch('requests.get')
+    def test_get_team_scores_ok(self,
+                                mock_request_call, mock_writer):
+        mock_request_call.side_effect = [mocked_requests_get({'fixtures': [1, 2]}, 200)]
+        mock_writer.return_value = mock.Mock()
+        self.rq.get_team_scores("AFC", 6, True, True)
+        mock_writer.assert_called_once()
+
+    @mock.patch('test_request_handler.click.secho')
+    @mock.patch('test_request_handler.Stdout.team_scores')
+    @mock.patch('requests.get')
+    def test_get_team_scores_0_fixtures(self,
+                                        mock_request_call,
+                                        mock_writer, mock_click):
+        mock_request_call.side_effect = [mocked_requests_get({'fixtures': []}, 200)]
+        mock_writer.return_value = mock.Mock()
+        self.rq.get_team_scores("AFC", 6, True, True)
+        mock_click.assert_called_with("No action during past week. Change the time "
+         "parameter to get more fixtures.", fg="red", bold=True)
+
+    @mock.patch('test_request_handler.click.secho')
+    @mock.patch('test_request_handler.Stdout.team_scores')
+    @mock.patch('requests.get')
+    def test_get_team_scores_bad_id(self,
+                                    mock_request_call,
+                                    mock_writer, mock_click):
+        mock_request_call.side_effect = [mocked_requests_get({'fixtures': [1, 2]}, 200)]
+        mock_writer.return_value = mock.Mock()
+        self.rq.get_team_scores("AdkljdfkljkdlFC", 6, True, True)
+        mock_click.assert_called_with("Team code is not correct.", fg="red", bold=True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_request_handler.py
+++ b/tests/test_request_handler.py
@@ -46,60 +46,49 @@ class TestRequestHandler(unittest.TestCase):
         mock_call.return_value = mock.MagicMock(
                 status_code=requests.codes.ok,
                 response=json.dumps({'key': 'value'}))
-        raised = False
         try:
             self.rq._get(self.dummy_url)
         except APIErrorException:
-            raised = True
-        self.assertFalse(raised is True)
+            self.fail("Threw exception erroneously")
 
     @mock.patch('requests.get')
     def test_bad_code(self, mock_call):
         mock_call.return_value = mock.MagicMock(
                 status_code=requests.codes.bad,
                 response=json.dumps({'key': 'value'}))
-        raised = False
-        try:
+        with self.assertRaises(APIErrorException) as context:
             self.rq._get(self.dummy_url)
-        except APIErrorException:
-            raised = True
-        self.assertTrue(raised is True)
+        self.assertTrue("Invalid request. "
+                        "Check parameters." in context.exception)
 
     @mock.patch('requests.get')
     def test_forbidden_code(self, mock_call):
         mock_call.return_value = mock.MagicMock(
                 status_code=requests.codes.forbidden,
                 response=json.dumps({'key': 'value'}))
-        raised = False
-        try:
+        with self.assertRaises(APIErrorException) as context:
             self.rq._get(self.dummy_url)
-        except APIErrorException:
-            raised = True
-        self.assertTrue(raised is True)
+        self.assertTrue('This resource is restricted' in context.exception)
 
     @mock.patch('requests.get')
     def test_not_found_code(self, mock_call):
         mock_call.return_value = mock.MagicMock(
                 status_code=requests.codes.not_found,
                 response=json.dumps({'key': 'value'}))
-        raised = False
-        try:
+        with self.assertRaises(APIErrorException) as context:
             self.rq._get(self.dummy_url)
-        except APIErrorException:
-            raised = True
-        self.assertTrue(raised is True)
+        self.assertTrue("This resource does not exist. "
+                        "Check parameters" in context.exception)
 
     @mock.patch('requests.get')
     def test_too_many_requests_code(self, mock_call):
         mock_call.return_value = mock.MagicMock(
                 status_code=requests.codes.too_many_requests,
                 response=json.dumps({'key': 'value'}))
-        raised = False
-        try:
+        with self.assertRaises(APIErrorException) as context:
             self.rq._get(self.dummy_url)
-        except APIErrorException:
-            raised = True
-        self.assertTrue(raised is True)
+        self.assertTrue("You have exceeded your allowed "
+                        "requests per minute/day" in context.exception)
 
     @mock.patch('test_request_handler.Stdout.live_scores')
     @mock.patch('requests.get')
@@ -118,7 +107,8 @@ class TestRequestHandler(unittest.TestCase):
         mock_request_call.side_effect = [mocked_requests_get({'games': []}, 200)]
         mock_writer.return_value = mock.Mock()
         self.rq.get_live_scores(True)
-        mock_click.assert_called_with("No live action currently", fg="red", bold=True)
+        mock_click.assert_called_with("No live action "
+                                      "currently", fg="red", bold=True)
 
     @mock.patch('test_request_handler.click.secho')
     @mock.patch('test_request_handler.Stdout.live_scores')
@@ -129,7 +119,8 @@ class TestRequestHandler(unittest.TestCase):
         mock_request_call.side_effect = [mocked_requests_get({'games': [1, 2]}, 400)]
         mock_writer.return_value = mock.Mock()
         self.rq.get_live_scores(True)
-        mock_click.assert_called_with("There was problem getting live scores", fg="red", bold=True)
+        mock_click.assert_called_with("There was problem getting "
+                                      "live scores", fg="red", bold=True)
 
     @mock.patch('test_request_handler.Stdout.team_scores')
     @mock.patch('requests.get')
@@ -149,8 +140,10 @@ class TestRequestHandler(unittest.TestCase):
         mock_request_call.side_effect = [mocked_requests_get({'fixtures': []}, 200)]
         mock_writer.return_value = mock.Mock()
         self.rq.get_team_scores("AFC", 6, True, True)
-        mock_click.assert_called_with("No action during past week. Change the time "
-         "parameter to get more fixtures.", fg="red", bold=True)
+        mock_click.assert_called_with("No action during"
+                                      " past week. Change the time "
+                                      "parameter to get "
+                                      "more fixtures.", fg="red", bold=True)
 
     @mock.patch('test_request_handler.click.secho')
     @mock.patch('test_request_handler.Stdout.team_scores')
@@ -161,7 +154,8 @@ class TestRequestHandler(unittest.TestCase):
         mock_request_call.side_effect = [mocked_requests_get({'fixtures': [1, 2]}, 200)]
         mock_writer.return_value = mock.Mock()
         self.rq.get_team_scores("AdkljdfkljkdlFC", 6, True, True)
-        mock_click.assert_called_with("Team code is not correct.", fg="red", bold=True)
+        mock_click.assert_called_with("Team code is not "
+                                      "correct.", fg="red", bold=True)
 
 
 if __name__ == '__main__':

--- a/tests/test_request_handler.py
+++ b/tests/test_request_handler.py
@@ -6,13 +6,10 @@ import requests
 import unittest
 import leagueids
 import mock
-import click
-from main import load_json
 from mock_response import MockResponse
 from soccer.exceptions import APIErrorException
 from request_handler import RequestHandler
 from soccer.writers import get_writer
-from soccer.writers import Stdout
 
 
 def mocked_requests_get(*args, **kwargs):
@@ -90,54 +87,59 @@ class TestRequestHandler(unittest.TestCase):
         self.assertTrue("You have exceeded your allowed "
                         "requests per minute/day" in context.exception)
 
-    @mock.patch('test_request_handler.Stdout.live_scores')
+    @mock.patch('soccer.writers.Stdout.live_scores')
     @mock.patch('requests.get')
     def test_get_live_scores_ok(self, mock_request_call, mock_writer):
-        mock_request_call.side_effect = [mocked_requests_get({'games': [1, 2]}, 200)]
+        mock_request_call.side_effect = \
+            [mocked_requests_get({'games': [1, 2]}, 200)]
         mock_writer.return_value = mock.Mock()
         self.rq.get_live_scores(True)
         mock_writer.assert_called_once()
 
-    @mock.patch('test_request_handler.click.secho')
-    @mock.patch('test_request_handler.Stdout.live_scores')
+    @mock.patch('click.secho')
+    @mock.patch('soccer.writers.Stdout.live_scores')
     @mock.patch('requests.get')
     def test_get_live_scores_0_games(self,
                                      mock_request_call, mock_writer,
                                      mock_click):
-        mock_request_call.side_effect = [mocked_requests_get({'games': []}, 200)]
+        mock_request_call.side_effect = \
+            [mocked_requests_get({'games': []}, 200)]
         mock_writer.return_value = mock.Mock()
         self.rq.get_live_scores(True)
         mock_click.assert_called_with("No live action "
                                       "currently", fg="red", bold=True)
 
-    @mock.patch('test_request_handler.click.secho')
-    @mock.patch('test_request_handler.Stdout.live_scores')
+    @mock.patch('click.secho')
+    @mock.patch('soccer.writers.Stdout.live_scores')
     @mock.patch('requests.get')
     def test_get_live_scores_error(self,
                                    mock_request_call, mock_writer,
                                    mock_click):
-        mock_request_call.side_effect = [mocked_requests_get({'games': [1, 2]}, 400)]
+        mock_request_call.side_effect = \
+            [mocked_requests_get({'games': [1, 2]}, 400)]
         mock_writer.return_value = mock.Mock()
         self.rq.get_live_scores(True)
         mock_click.assert_called_with("There was problem getting "
                                       "live scores", fg="red", bold=True)
 
-    @mock.patch('test_request_handler.Stdout.team_scores')
+    @mock.patch('soccer.writers.Stdout.team_scores')
     @mock.patch('requests.get')
     def test_get_team_scores_ok(self,
                                 mock_request_call, mock_writer):
-        mock_request_call.side_effect = [mocked_requests_get({'fixtures': [1, 2]}, 200)]
+        mock_request_call.side_effect = \
+            [mocked_requests_get({'fixtures': [1, 2]}, 200)]
         mock_writer.return_value = mock.Mock()
         self.rq.get_team_scores("AFC", 6, True, True)
         mock_writer.assert_called_once()
 
-    @mock.patch('test_request_handler.click.secho')
-    @mock.patch('test_request_handler.Stdout.team_scores')
+    @mock.patch('click.secho')
+    @mock.patch('soccer.writers.Stdout.team_scores')
     @mock.patch('requests.get')
     def test_get_team_scores_0_fixtures(self,
                                         mock_request_call,
                                         mock_writer, mock_click):
-        mock_request_call.side_effect = [mocked_requests_get({'fixtures': []}, 200)]
+        mock_request_call.side_effect = \
+            [mocked_requests_get({'fixtures': []}, 200)]
         mock_writer.return_value = mock.Mock()
         self.rq.get_team_scores("AFC", 6, True, True)
         mock_click.assert_called_with("No action during"
@@ -145,13 +147,14 @@ class TestRequestHandler(unittest.TestCase):
                                       "parameter to get "
                                       "more fixtures.", fg="red", bold=True)
 
-    @mock.patch('test_request_handler.click.secho')
-    @mock.patch('test_request_handler.Stdout.team_scores')
+    @mock.patch('click.secho')
+    @mock.patch('soccer.writers.Stdout.team_scores')
     @mock.patch('requests.get')
     def test_get_team_scores_bad_id(self,
                                     mock_request_call,
                                     mock_writer, mock_click):
-        mock_request_call.side_effect = [mocked_requests_get({'fixtures': [1, 2]}, 200)]
+        mock_request_call.side_effect = \
+            [mocked_requests_get({'fixtures': [1, 2]}, 200)]
         mock_writer.return_value = mock.Mock()
         self.rq.get_team_scores("AdkljdfkljkdlFC", 6, True, True)
         mock_click.assert_called_with("Team code is not "


### PR DESCRIPTION
Hey guys,

1) I wrote a few tests here for request_handler.py, the new module I refactored out. As of now I just added tests for three methods from the RequestHandler class to get some feedback. I used MagicMock to mock out the api calls, and basically ran a few tests to make sure the proper code was called. Was looking just to get some code coverage going.

 2) I also simplified some of the tests from test_load_data.py as per the discussion from #110 that @Saturn suggested.

3) I also added mock==1.0.1 to the requirements.txt file.

4) As mentioned in a previous PR to run all tests run the following command: "python -m unittest discover tests" from the root of the repo. This will go into tests/ and look to run __all__ tests

Thanks for any feedback :)
Andy