### PR TITLE
bug fixed: invalid header value, was adding newline char

### DIFF
--- a/soccer/main.py
+++ b/soccer/main.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import re
 
 import click
 
@@ -60,7 +61,7 @@ def load_config_key():
             with open(config, "r") as cfile:
                 key = cfile.read()
         if key:
-            api_token = key
+            api_token = re.sub(r"[\n\t\s]*", "", key)
         else:
             os.remove(config)  # remove 0-byte file
             click.secho('No API Token detected. '


### PR DESCRIPTION
somehow creating ~/.soccer-cli.ini file and reading api key with this file was giving continuous Value Error: Invalid header value `ValueError: Invalid header value '*******************\n'`

after cleaning the read input of api key for any whitespace, newline and tab character, its working fine